### PR TITLE
Update ansible-collection-to-dhall nix file for external import

### DIFF
--- a/ansible-collection-to-dhall/default.nix
+++ b/ansible-collection-to-dhall/default.nix
@@ -1,13 +1,2 @@
-{ withHoogle ? false}:
-let
-  nixpkgs = import (fetchTarball
-    "https://github.com/NixOS/nixpkgs/archive/a6f258f49fcd1644f08b7b3677da2c5e55713291.tar.gz")
-    { };
-  name = "ansible-collection-to-dhall";
-  drv = nixpkgs.haskellPackages.callCabal2nix name ./. { };
-  shellDrv = nixpkgs.haskellPackages.shellFor {
-    withHoogle = withHoogle;
-    packages = p: [ drv ];
-    buildInputs = with nixpkgs.haskellPackages; [ hlint cabal-install ];
-  };
-in if nixpkgs.lib.inNixShell then shellDrv else drv
+{ pkgs ? import ./nixpkgs.nix }:
+pkgs.haskellPackages.callCabal2nix "ansible-collection-to-dhall" ./. { }

--- a/ansible-collection-to-dhall/nixpkgs.nix
+++ b/ansible-collection-to-dhall/nixpkgs.nix
@@ -1,0 +1,4 @@
+# A pinned nixpkgs
+import (fetchTarball
+  "https://github.com/NixOS/nixpkgs/archive/a6f258f49fcd1644f08b7b3677da2c5e55713291.tar.gz")
+{ }

--- a/ansible-collection-to-dhall/shell.nix
+++ b/ansible-collection-to-dhall/shell.nix
@@ -1,0 +1,9 @@
+{ withHoogle ? false }:
+let
+  nixpkgs = import ./nixpkgs.nix;
+  drv = import ./default.nix { };
+in nixpkgs.haskellPackages.shellFor {
+  withHoogle = withHoogle;
+  packages = p: [ drv ];
+  buildInputs = with nixpkgs.haskellPackages; [ hlint cabal-install ];
+}


### PR DESCRIPTION
This change split the nix expressions into different file to enable
using callPackage from another nix-shell.

Fixes: #22